### PR TITLE
support params in callback

### DIFF
--- a/src/taskphp/lib/TaskManage.php
+++ b/src/taskphp/lib/TaskManage.php
@@ -79,10 +79,14 @@ class TaskManage{
 		        Utils::log($callback[0].'::'.$callback[1].' [--START--]');
 		    }
 		    ob_start();
-		    $a = array_chunk($callback, 2);
-		    $callbackFunc = $a[0];
-		    $params = $a[1][0];
-		    call_user_func($callbackFunc, $params);
+		    if (count($callback) > 2){
+		        $a = array_chunk($callback, 2);
+		        $callbackFunc = $a[0];
+		        $params = $a[1][0];
+		        call_user_func($callbackFunc, $params);
+		    } else {
+		    	call_user_func($callback);
+		    }
 		    $data=ob_get_contents();
 		    ob_end_clean();
 		    if(Utils::config('log')['debug']){

--- a/src/taskphp/lib/TaskManage.php
+++ b/src/taskphp/lib/TaskManage.php
@@ -79,7 +79,10 @@ class TaskManage{
 		        Utils::log($callback[0].'::'.$callback[1].' [--START--]');
 		    }
 		    ob_start();
-		    call_user_func($callback);
+		    $a = array_chunk($callback, 2);
+		    $callbackFunc = $a[0];
+		    $params = $a[1][0];
+		    call_user_func($callbackFunc, $params);
 		    $data=ob_get_contents();
 		    ob_end_clean();
 		    if(Utils::config('log')['debug']){


### PR DESCRIPTION
实际使用中存在一种场景，callback中的方法只是一个入口方法，具体执行逻辑依赖于方法的传参。 所以是否可以考虑在callback数组中增加第三个参数，用来传参，使得调度的方法更加灵活。

Taskphp.php中这样使用：
```
for($x = 0; $x < $length; $x++){
		$v = "demo" . $x;
		$list["task_list"][$v] = [
				'callback'=>['app\index\command\Demo','run', $v],//任务调用:类名和方法
				//指定任务进程最大内存  系统默认为512M
				'worker_memory'      =>'1024M',
				//开启任务进程的多线程模式
				'worker_pthreads'   =>false,
				//任务的进程数 系统默认1
				'worker_count'=>1,
				//crontad格式 :秒 分 时 天 月 年 周
				'crontab'     =>'/' . (5+$x) . ' * * * * * *',
			];
}
```

Demo.php中如下
```
<?php
namespace app\index\command;

use taskphp\Utils;
/**
 * 测试任务 
 */
class Demo{
    /**
     * demo任务入口
     */
	public static function run($a){
	    Utils::log('demo1任务运行成功' . $a);	
	    //可以调用thinkphp内的json函数
	    //Utils::log(json(['message'=>'hello taskphp'])); 
	}
}
```